### PR TITLE
feat(Proton Mail): add three patches

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/protonmail/account/RemoveFreeAccountsLimitPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/protonmail/account/RemoveFreeAccountsLimitPatch.kt
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ByteEVM
+ * SPDX-FileCopyrightText: 2026 hxreborn
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Ported from hxreborn/revanced-patches:
+ * https://gitlab.com/hxreborn/revanced-patches/-/commit/49ae0df224f42bc511d3e4d748c6b94f6273b44c
+ * Commit 49ae0df224f42bc511d3e4d748c6b94f6273b44c (2025-05-30),
+ * patches/src/main/kotlin/app/revanced/patches/protonmail/account/RemoveFreeAccountsLimitPatch.kt
+ */
+package app.morphe.patches.protonmail.account
+
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.util.findElementByAttributeValueOrThrow
+
+@Suppress("unused")
+val removeFreeAccountsLimitPatch = resourcePatch(
+    name = "Remove free accounts limit",
+    description = "Removes the limit for maximum free accounts logged in.",
+) {
+    compatibleWith(AppCompatibilities.PROTON_MAIL)
+
+    execute {
+        document("res/values/integers.xml").use { document ->
+            document.documentElement.childNodes.findElementByAttributeValueOrThrow(
+                "name",
+                "core_feature_auth_user_check_max_free_user_count",
+            ).textContent = Int.MAX_VALUE.toString()
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/protonmail/misc/upselling/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/protonmail/misc/upselling/Fingerprints.kt
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2026 hxreborn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package app.morphe.patches.protonmail.misc.upselling
+
+import app.morphe.patcher.Fingerprint
+
+internal object SidebarUpsellingFeatureFlagFingerprint : Fingerprint(
+    strings = listOf("MailAndroidUpsellingSidebar"),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/protonmail/misc/upselling/HideSidebarUpsellingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/protonmail/misc/upselling/HideSidebarUpsellingPatch.kt
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2026 hxreborn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package app.morphe.patches.protonmail.misc.upselling
+
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+
+@Suppress("unused")
+val hideSidebarUpsellingPatch = bytecodePatch(
+    name = "Hide sidebar upselling",
+    description = "Hides the 'Upgrade to Mail Plus' entry from the sidebar.",
+) {
+    compatibleWith(AppCompatibilities.PROTON_MAIL)
+
+    execute {
+        SidebarUpsellingFeatureFlagFingerprint.method.apply {
+            val flagIndex = indexOfFirstInstructionOrThrow {
+                opcode == Opcode.CONST_STRING &&
+                    getReference<StringReference>()?.string == "MailAndroidUpsellingSidebar"
+            }
+            val resultIndex = indexOfFirstInstructionOrThrow(flagIndex, Opcode.MOVE_RESULT)
+            val register = getInstruction<OneRegisterInstruction>(resultIndex).registerA
+
+            replaceInstruction(resultIndex, "const/16 v$register, 0x0")
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/protonmail/signature/RemoveSentFromSignaturePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/protonmail/signature/RemoveSentFromSignaturePatch.kt
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Aoife McCullough
+ * SPDX-FileCopyrightText: 2026 hxreborn
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Ported from hxreborn/revanced-patches:
+ * https://gitlab.com/hxreborn/revanced-patches/-/commit/8ed9d5bf087d8392e945d471c2a42b52a393ceaf
+ * Commit 8ed9d5bf087d8392e945d471c2a42b52a393ceaf (2025-04-02),
+ * patches/src/main/kotlin/app/revanced/patches/protonmail/signature/RemoveSentFromSignaturePatch.kt
+ */
+package app.morphe.patches.protonmail.signature
+
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.util.findElementByAttributeValue
+
+@Suppress("unused")
+val removeSentFromSignaturePatch = resourcePatch(
+    name = "Remove 'Sent from' signature",
+    description = "Removes the 'Sent from Proton Mail mobile' signature from emails.",
+) {
+    compatibleWith(AppCompatibilities.PROTON_MAIL)
+
+    execute {
+        val resourceDirectory = get("res")
+
+        val blankedStrings = resourceDirectory.walk()
+            .filter { it.isFile && it.name.equals("strings.xml", ignoreCase = true) }
+            .count { stringsFile ->
+                val path = "res/${stringsFile.relativeTo(resourceDirectory).invariantSeparatorsPath}"
+
+                document(path).use { document ->
+                    // Not localized in all languages
+                    document.documentElement.childNodes.findElementByAttributeValue(
+                        "name",
+                        "mail_settings_identity_mobile_footer_default_free",
+                    )?.apply { textContent = "" } != null
+                }
+            }
+
+        if (blankedStrings == 0) throw PatchException("Could not find 'sent from' string in resources")
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: GPL-3.0-only
  *
  * Central Morphe `Compatibility` metadata so Morphe Manager shows human-readable
- * app names and icons. No targets: patches apply to any app version.
+ * app names and icons. Targets are set only where patches break on newer versions.
  */
 package app.morphe.patches.shared.compat
 
 import app.morphe.patcher.patch.ApkFileType
+import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.Compatibility
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -24,6 +25,15 @@ internal object AppCompatibilities {
         packageName = "com.spocky.projengmenu",
         apkFileType = ApkFileType.APK,
         appIconColor = 0xF08029,
+    )
+
+    // Pinned to the last version ReVanced verified these patches against
+    val PROTON_MAIL = Compatibility(
+        name = "Proton Mail",
+        packageName = "ch.protonmail.android",
+        apkFileType = ApkFileType.APK,
+        appIconColor = 0x6D4AFF,
+        targets = listOf(AppTarget(version = "4.15.0", versionCode = 11782, minSdk = 28)),
     )
 
     val SHOWLY = Compatibility(


### PR DESCRIPTION
Ports `Remove free accounts limit` and `Remove 'Sent from' signature` from ReVanced, adds `Hide sidebar upselling`.

Fingerprints verified against stock 4.15.0 (11782)