### PR TITLE
docs: link each patch in the list to its source and restyle the README header

### DIFF
--- a/.github/scripts/generate_patches_readme.py
+++ b/.github/scripts/generate_patches_readme.py
@@ -70,13 +70,56 @@ def slug(text):
     return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", text.lower())).strip("-")
 
 
-def patches_table(patches, app_slug):
+PATCHES_SRC  = Path("patches/src/main/kotlin")
+COMPAT_FILE  = PATCHES_SRC / "app/morphe/patches/shared/compat/AppCompatibilities.kt"
+
+
+def build_source_index():
+    """Map (patch name, packageName) -> source file. Patch names repeat across apps,
+    so the compatibility constant is what tells three "Unlock premium" patches apart."""
+    if not PATCHES_SRC.is_dir():
+        return {}
+
+    compat = {}
+    if COMPAT_FILE.is_file():
+        text = COMPAT_FILE.read_text(encoding="utf-8")
+        for const, body in re.findall(r"val (\w+) = Compatibility\((.*?)\n    \)", text, re.DOTALL):
+            pkg = re.search(r'packageName = "([^"]+)"', body)
+            if pkg:
+                compat[const] = pkg.group(1)
+
+    index = {}
+    for path in PATCHES_SRC.rglob("*.kt"):
+        if path == COMPAT_FILE:
+            continue
+        text = path.read_text(encoding="utf-8")
+        names = re.findall(r'^\s{4}name = "([^"]+)"', text, re.MULTILINE)
+        if not names:
+            continue
+        consts = re.findall(r"compatibleWith\(\s*AppCompatibilities\.(\w+)", text)
+        pkgs = [compat.get(c) for c in consts] or [None]
+        for name in names:
+            for pkg in pkgs:
+                index.setdefault((name, pkg), path.as_posix())
+    return index
+
+
+SOURCES = build_source_index()
+
+
+def patch_cell(patch, pkg, pid):
+    source = SOURCES.get((patch["name"], pkg))
+    label = f'[{patch["name"]}]({source})' if source else patch["name"]
+    return f'<a id="{pid}"></a>{label}'
+
+
+def patches_table(patches, app_slug, pkg=None):
     """Render a sorted markdown table of patches with name, description, and options.
 
-    Each patch name carries an explicit <a id="app-patch"> anchor. The app slug is
-    part of the id because patch names repeat across apps (three "Unlock premium"
-    patches here), and GitHub's heading-derived ids would collide and get -1/-2
-    suffixes that shift whenever the list changes.
+    Each patch name links to its source file and carries an explicit <a id="app-patch">
+    anchor for deep links. The app slug is part of the id because patch names repeat
+    across apps (three "Unlock premium" patches here), and GitHub's heading-derived ids
+    would collide and get -1/-2 suffixes that shift whenever the list changes.
 
     The Options column is omitted entirely when no patch in the table has options,
     so it never renders as an empty column that looks broken.
@@ -85,13 +128,13 @@ def patches_table(patches, app_slug):
     has_options = any(p.get("options") for p in patches)
 
     if has_options:
-        rows = ["| Patch | Description | Options |", "|----------|----------------|-----------|"]
+        rows = ["| 💊&nbsp;Patch | 📜&nbsp;Description | ⚙️&nbsp;Options |", "|----------|----------------|-----------|"]
     else:
-        rows = ["| Patch | Description |", "|----------|----------------|"]
+        rows = ["| 💊&nbsp;Patch | 📜&nbsp;Description |", "|----------|----------------|"]
 
     for p in patches:
         pid = f"{app_slug}-{slug(p['name'])}"
-        cell = f'<a id="{pid}"></a>[{p["name"]}](#{pid})'
+        cell = patch_cell(p, pkg, pid)
         desc = (p.get("description") or "").replace("\n", "<br>")
         if not has_options:
             rows.append(f"| {cell} | {desc} |")
@@ -117,7 +160,7 @@ def versions_table(targets):
         ver   = t["version"]
         if ver is None:
             continue
-        label = f"{ver} (experimental)" if t.get("isExperimental") else ver
+        label = f"🧪&nbsp;{ver}" if t.get("isExperimental") else ver
         cells.append(label)
 
     if not cells:
@@ -189,11 +232,11 @@ def sibling_targets(url, pkg):
 
 
 def icon_img(pkg):
-    """Inline <img> for an app, or empty string if we have no icon for it.
+    """Inline <img> for an app, or a generic package emoji when it has no icon.
     Relative path so it resolves on any branch and in forks."""
     filename = ICONS.get(pkg)
     if not filename:
-        return ""
+        return "📦&nbsp;"
     return f'<img src=".github/assets/icons/{filename}" width="18" align="top">&nbsp;&nbsp;'
 
 
@@ -203,7 +246,7 @@ def spoiler(label, count, targets, tbl, expanded=False, pkg=None):
     """
     noun = "patch" if count == 1 else "patches"
     vtbl = versions_table(targets)
-    versions_section = f"**Supported versions:**\n\n{vtbl}\n\n" if vtbl else ""
+    versions_section = f"**🎯 Supported versions:**\n\n{vtbl}\n\n" if vtbl else ""
     tag = "<details open>" if expanded else "<details>"
     return f"""{tag}
 <summary>{icon_img(pkg)}{label}&nbsp;&nbsp;•&nbsp;&nbsp;{count} {noun}</summary>
@@ -226,19 +269,19 @@ def build_content(expanded=False):
     for pkg, entry in by_pkg.items():
         patches = list(entry["patches"].values())
         label   = entry["name"]
-        lines.append(spoiler(label, len(patches), entry["targets"], patches_table(patches, slug(label)), expanded, pkg))
+        lines.append(spoiler(label, len(patches), entry["targets"], patches_table(patches, slug(label), pkg), expanded, pkg))
         lines.append("")
 
     # TikTok ships as its own bundle, so it has no entry in patches-list.json.
     # Rendered here so the catalog lists it alongside the apps in this bundle.
     tiktok_versions = versions_table(sibling_targets(TIKTOK_LIST, TIKTOK_PKG))
-    tiktok_section = f"**Supported versions:**\n\n{tiktok_versions}\n\n" if tiktok_versions else ""
+    tiktok_section = f"**🎯 Supported versions:**\n\n{tiktok_versions}\n\n" if tiktok_versions else ""
 
     lines.append(f"""{"<details open>" if expanded else "<details>"}
 <summary>{icon_img(TIKTOK_PKG)}TikTok&nbsp;&nbsp;•&nbsp;&nbsp;separate bundle</summary>
 <br>
 
-{tiktok_section}| Bundle | Description |
+{tiktok_section}| 📦&nbsp;Bundle | 📜&nbsp;Description |
 |----------|----------------|
 | [hxreborn-tiktok-patches](https://github.com/{TIKTOK_REPO}) | Not part of this bundle, so it has to be added to Morphe as its own patch source. Forked from [icysymmetra/tiktok-patches-for-morphe](https://github.com/icysymmetra/tiktok-patches-for-morphe). [Add to Morphe](https://morphe.software/add-source?github={TIKTOK_REPO}) |
 
@@ -251,7 +294,7 @@ def build_content(expanded=False):
         noun = "patch" if len(uni_patches) == 1 else "patches"
         tag  = "<details open>" if expanded else "<details>"
         lines.append(f"""{tag}
-<summary>Universal&nbsp;&nbsp;•&nbsp;&nbsp;{len(uni_patches)} {noun}</summary>
+<summary>🌐&nbsp;Universal&nbsp;&nbsp;•&nbsp;&nbsp;{len(uni_patches)} {noun}</summary>
 <br>
 
 {patches_table(uni_patches, "universal")}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,32 @@
+<div align="center">
+
 # 🧩 hxreborn Patches
 
-Patches for Android apps I use, built for Morphe.
+**Patches for the Android apps I use, built for [Morphe](https://morphe.software).**
 
+[![Release badge](https://img.shields.io/github/v/release/hxreborn/morphe-patches?style=for-the-badge&label=Release&color=gray)](https://github.com/hxreborn/morphe-patches/releases/latest)
+[![Documentation badge](https://img.shields.io/badge/Documentation-gray?style=for-the-badge&logo=github)](https://github.com/MorpheApp/morphe-documentation#readme)
+[![License badge](https://img.shields.io/badge/License-GPLv3-gray?style=for-the-badge)](LICENSE)
+
+<a href="https://morphe.software/add-source?github=hxreborn/morphe-patches" title="Add this source to Morphe">
+  <img alt="Add to Morphe" src="https://img.shields.io/badge/Morphe-Add%20this%20source-00A8FF?style=for-the-badge" height="38"/>
+</a>
+
+</div>
+
+&nbsp;
 ## ❓ About
 
 I maintain these because I use them.
-Built with [Morphe](https://morphe.software).
 
-Based off the prior work of [ReVanced](https://github.com/ReVanced). All
-modifications made here, along with their dates, can be found in the Git history.
+Based off the prior work of [ReVanced](https://github.com/ReVanced). All modifications made
+here, along with their dates, can be found in the Git history.
 
 App icons in the patches list belong to their respective developers and are used only to
 identify each app. They are not covered by this repository's licence. See
 [the icon notice](.github/assets/icons/README.md).
 
+&nbsp;
 ## 🩹 Patches list
 
 <!-- PATCHES_START EXPANDED -->
@@ -22,9 +35,9 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/kick.png" width="18" align="top">&nbsp;&nbsp;Kick&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="kick-amoled-dark-theme"></a>[AMOLED dark theme](#kick-amoled-dark-theme) | Replaces the dark theme background with pure black. Disables over-the-air updates that would restore the original background. |
+| <a id="kick-amoled-dark-theme"></a>[AMOLED dark theme](patches/src/main/kotlin/app/morphe/patches/kick/misc/theme/AmoledThemePatch.kt) | Replaces the dark theme background with pure black. Disables over-the-air updates that would restore the original background. |
 
 </details>
 
@@ -32,9 +45,9 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/perplexity.png" width="18" align="top">&nbsp;&nbsp;Perplexity&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="perplexity-amoled-dark-theme"></a>[AMOLED dark theme](#perplexity-amoled-dark-theme) | Replaces the dark theme background with pure black. |
+| <a id="perplexity-amoled-dark-theme"></a>[AMOLED dark theme](patches/src/main/kotlin/app/morphe/patches/perplexity/misc/theme/AmoledThemePatch.kt) | Replaces the dark theme background with pure black. |
 
 </details>
 
@@ -42,19 +55,19 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/protonmail.png" width="18" align="top">&nbsp;&nbsp;Proton Mail&nbsp;&nbsp;•&nbsp;&nbsp;6 patches</summary>
 <br>
 
-**Supported versions:**
+**🎯 Supported versions:**
 
 | 7.10.4 |
 | :---: |
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="proton-mail-amoled-dark-theme"></a>[AMOLED dark theme](#proton-mail-amoled-dark-theme) | Replaces the dark theme background with pure black. |
-| <a id="proton-mail-hide-upgrade-upselling"></a>[Hide upgrade upselling](#proton-mail-hide-upgrade-upselling) | Hides the top-bar upgrade button and promotional sidebar rows. |
-| <a id="proton-mail-remove-sent-from-signature"></a>[Remove 'Sent from' signature](#proton-mail-remove-sent-from-signature) | Removes the 'Sent from Proton Mail' signature from emails. |
-| <a id="proton-mail-remove-free-accounts-limit"></a>[Remove free accounts limit](#proton-mail-remove-free-accounts-limit) | Removes the limit for maximum free accounts logged in. |
-| <a id="proton-mail-spoof-signature"></a>[Spoof signature](#proton-mail-spoof-signature) | Restores push notifications by spoofing the original app signature. |
-| <a id="proton-mail-unlock-custom-time-picker"></a>[Unlock custom time picker](#proton-mail-unlock-custom-time-picker) | Enables picking a custom date and time when snoozing conversations and scheduling messages. |
+| <a id="proton-mail-amoled-dark-theme"></a>[AMOLED dark theme](patches/src/main/kotlin/app/morphe/patches/protonmail/misc/theme/AmoledThemePatch.kt) | Replaces the dark theme background with pure black. |
+| <a id="proton-mail-hide-upgrade-upselling"></a>[Hide upgrade upselling](patches/src/main/kotlin/app/morphe/patches/protonmail/misc/upselling/HideUpgradeUpsellingPatch.kt) | Hides the top-bar upgrade button and promotional sidebar rows. |
+| <a id="proton-mail-remove-sent-from-signature"></a>[Remove 'Sent from' signature](patches/src/main/kotlin/app/morphe/patches/protonmail/signature/RemoveSentFromSignaturePatch.kt) | Removes the 'Sent from Proton Mail' signature from emails. |
+| <a id="proton-mail-remove-free-accounts-limit"></a>[Remove free accounts limit](patches/src/main/kotlin/app/morphe/patches/protonmail/account/RemoveFreeAccountsLimitPatch.kt) | Removes the limit for maximum free accounts logged in. |
+| <a id="proton-mail-spoof-signature"></a>[Spoof signature](patches/src/main/kotlin/app/morphe/patches/protonmail/misc/fix/signature/SpoofSignaturePatch.kt) | Restores push notifications by spoofing the original app signature. |
+| <a id="proton-mail-unlock-custom-time-picker"></a>[Unlock custom time picker](patches/src/main/kotlin/app/morphe/patches/protonmail/misc/scheduling/UnlockCustomTimePickerPatch.kt) | Enables picking a custom date and time when snoozing conversations and scheduling messages. |
 
 </details>
 
@@ -62,10 +75,10 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/showly.png" width="18" align="top">&nbsp;&nbsp;Showly&nbsp;&nbsp;•&nbsp;&nbsp;2 patches</summary>
 <br>
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="showly-amoled-dark-theme"></a>[AMOLED dark theme](#showly-amoled-dark-theme) | Replaces the dark theme background with pure black. |
-| <a id="showly-unlock-premium"></a>[Unlock premium](#showly-unlock-premium) | Unlocks ad removal, light theme, custom images, list view types, quick ratings, and transparent widgets. The News feed is not included. |
+| <a id="showly-amoled-dark-theme"></a>[AMOLED dark theme](patches/src/main/kotlin/app/morphe/patches/showly/misc/theme/AmoledThemePatch.kt) | Replaces the dark theme background with pure black. |
+| <a id="showly-unlock-premium"></a>[Unlock premium](patches/src/main/kotlin/app/morphe/patches/showly/misc/premium/UnlockPremiumPatch.kt) | Unlocks ad removal, light theme, custom images, list view types, quick ratings, and transparent widgets. The News feed is not included. |
 
 </details>
 
@@ -73,10 +86,10 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/projectivy.png" width="18" align="top">&nbsp;&nbsp;Projectivy Launcher&nbsp;&nbsp;•&nbsp;&nbsp;2 patches</summary>
 <br>
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="projectivy-launcher-disable-tracking"></a>[Disable tracking](#projectivy-launcher-disable-tracking) | Disables analytics and crash reporting. |
-| <a id="projectivy-launcher-unlock-premium"></a>[Unlock premium](#projectivy-launcher-unlock-premium) | Unlocks all premium features. |
+| <a id="projectivy-launcher-disable-tracking"></a>[Disable tracking](patches/src/main/kotlin/app/morphe/patches/projectivy/misc/tracking/DisableTrackingPatch.kt) | Disables analytics and crash reporting. |
+| <a id="projectivy-launcher-unlock-premium"></a>[Unlock premium](patches/src/main/kotlin/app/morphe/patches/projectivy/misc/premium/UnlockPremiumPatch.kt) | Unlocks all premium features. |
 
 </details>
 
@@ -84,14 +97,14 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/etsy.png" width="18" align="top">&nbsp;&nbsp;Etsy&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-**Supported versions:**
+**🎯 Supported versions:**
 
 | 7.90.0 |
 | :---: |
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="etsy-hide-ads"></a>[Hide ads](#etsy-hide-ads) | Removes promoted listings and the "with Ads" label from search results. |
+| <a id="etsy-hide-ads"></a>[Hide ads](patches/src/main/kotlin/app/morphe/patches/etsy/ads/HideAdsPatch.kt) | Removes promoted listings and the "with Ads" label from search results. |
 
 </details>
 
@@ -99,14 +112,14 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/qrscanner.png" width="18" align="top">&nbsp;&nbsp;QR & Barcode Scanner&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-**Supported versions:**
+**🎯 Supported versions:**
 
 | 2.2.221 |
 | :---: |
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="qr-barcode-scanner-hide-ads"></a>[Hide ads](#qr-barcode-scanner-hide-ads) | Disables banner, interstitial, and native ads. |
+| <a id="qr-barcode-scanner-hide-ads"></a>[Hide ads](patches/src/main/kotlin/app/morphe/patches/gammascan/ads/HideAdsPatch.kt) | Disables banner, interstitial, and native ads. |
 
 </details>
 
@@ -114,14 +127,14 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/trainline.png" width="18" align="top">&nbsp;&nbsp;Trainline&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-**Supported versions:**
+**🎯 Supported versions:**
 
 | 407.0.0.178994 |
 | :---: |
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="trainline-hide-ads"></a>[Hide ads](#trainline-hide-ads) | Removes the adverts shown between search results. |
+| <a id="trainline-hide-ads"></a>[Hide ads](patches/src/main/kotlin/app/morphe/patches/trainline/ads/HideAdsPatch.kt) | Removes the adverts shown between search results. |
 
 </details>
 
@@ -129,10 +142,10 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/audible.png" width="18" align="top">&nbsp;&nbsp;Audible&nbsp;&nbsp;•&nbsp;&nbsp;2 patches</summary>
 <br>
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="audible-hide-membership-upselling"></a>[Hide membership upselling](#audible-hide-membership-upselling) | Hides the membership promotion on the Home screen and the free trial bottom sheet. |
-| <a id="audible-open-library-on-launch"></a>[Open Library on launch](#audible-open-library-on-launch) | Opens the Library tab instead of Home on launch. Applies only while signed in. |
+| <a id="audible-hide-membership-upselling"></a>[Hide membership upselling](patches/src/main/kotlin/app/morphe/patches/audible/misc/upselling/HideMembershipUpsellingPatch.kt) | Hides the membership promotion on the Home screen and the free trial bottom sheet. |
+| <a id="audible-open-library-on-launch"></a>[Open Library on launch](patches/src/main/kotlin/app/morphe/patches/audible/startup/OpenLibraryOnLaunchPatch.kt) | Opens the Library tab instead of Home on launch. Applies only while signed in. |
 
 </details>
 
@@ -140,14 +153,14 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/readera.png" width="18" align="top">&nbsp;&nbsp;ReadEra&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-**Supported versions:**
+**🎯 Supported versions:**
 
 | 26.05.20+2300 |
 | :---: |
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="readera-remove-nags"></a>[Remove nags](#readera-remove-nags) | Removes the rate this app dialog and the promotional dialogs shown on startup. |
+| <a id="readera-remove-nags"></a>[Remove nags](patches/src/main/kotlin/app/morphe/patches/readera/misc/nags/RemoveNagsPatch.kt) | Removes the rate this app dialog and the promotional dialogs shown on startup. |
 
 </details>
 
@@ -155,9 +168,9 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/forus.png" width="18" align="top">&nbsp;&nbsp;ForusApp&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="forusapp-unlock-premium"></a>[Unlock premium](#forusapp-unlock-premium) | Unlocks all premium features. |
+| <a id="forusapp-unlock-premium"></a>[Unlock premium](patches/src/main/kotlin/app/morphe/patches/forus/misc/premium/UnlockPremiumPatch.kt) | Unlocks all premium features. |
 
 </details>
 
@@ -165,14 +178,14 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/symfonium.png" width="18" align="top">&nbsp;&nbsp;Symfonium&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
-**Supported versions:**
+**🎯 Supported versions:**
 
 | 14.0.0 | 14.1.0 |
 | :---: | :---: |
 
-| Patch | Description |
+| 💊&nbsp;Patch | 📜&nbsp;Description |
 |----------|----------------|
-| <a id="symfonium-unlock-premium"></a>[Unlock premium](#symfonium-unlock-premium) | Unlocks all premium features. |
+| <a id="symfonium-unlock-premium"></a>[Unlock premium](patches/src/main/kotlin/app/morphe/patches/symfonium/misc/premium/UnlockPremiumPatch.kt) | Unlocks all premium features. |
 
 </details>
 
@@ -180,28 +193,44 @@ identify each app. They are not covered by this repository's licence. See
 <summary><img src=".github/assets/icons/tiktok.png" width="18" align="top">&nbsp;&nbsp;TikTok&nbsp;&nbsp;•&nbsp;&nbsp;separate bundle</summary>
 <br>
 
-**Supported versions:**
+**🎯 Supported versions:**
 
 | 46.2.3 |
 | :---: |
 
-| Bundle | Description |
+| 📦&nbsp;Bundle | 📜&nbsp;Description |
 |----------|----------------|
 | [hxreborn-tiktok-patches](https://github.com/hxreborn/hxreborn-tiktok-patches) | Not part of this bundle, so it has to be added to Morphe as its own patch source. Forked from [icysymmetra/tiktok-patches-for-morphe](https://github.com/icysymmetra/tiktok-patches-for-morphe). [Add to Morphe](https://morphe.software/add-source?github=hxreborn/hxreborn-tiktok-patches) |
 
 </details>
 
 <!-- PATCHES_END -->
+&nbsp;
+## 📲 Installing
 
-#### How to use these patches
+[Add this source](https://morphe.software/add-source?github=hxreborn/morphe-patches) to Morphe
+Manager, then patch any app listed above.
 
-<a href="https://morphe.software/add-source?github=hxreborn/morphe-patches"><img alt="Add to Morphe" src="https://img.shields.io/badge/Morphe-Add%20Source-00A8FF?style=for-the-badge"></a>
+&nbsp;
+## 🛠️ Building
 
-### 🛠️ Building
+You need Java 21 and a GitHub token with `read:packages`:
 
-To build hxreborn Patches,
-you can follow the [Morphe documentation](https://github.com/MorpheApp/morphe-documentation).
+```bash
+./gradlew buildAndroid
+```
 
+The bundle lands in `patches/build/libs/`. See the
+[Morphe documentation](https://github.com/MorpheApp/morphe-documentation) for the full setup.
+
+&nbsp;
 ## 📜 License
 
-hxreborn Patches are licensed under the [GNU General Public License v3.0](LICENSE)
+hxreborn Patches are licensed under the [GNU General Public License v3.0](LICENSE), with
+additional conditions under GPLv3 Section 7 inherited from Morphe:
+
+- **Attribution (7b):** all original notices and disclaimers are preserved.
+- **Name & branding (7c & 7e):** the **"Morphe"** name, logos, and trademarks are not used to
+  brand this project, which is a third-party bundle *for use with* Morphe.
+
+See [NOTICE](NOTICE) for the full conditions.


### PR DESCRIPTION
Patch names in the list now link to their .kt source instead of a dead self-anchor.