### PR TITLE
feat(Symfonium - Unlock premium): support the 14.0.0 TV build

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -110,6 +110,7 @@ internal object AppCompatibilities {
         targets = listOf(
             AppTarget(version = "14.0.0", versionCode = 127708, minSdk = 28),
             AppTarget(version = "14.1.0", versionCode = 127734, minSdk = 32),
+            AppTarget(version = "14.0.0 TV", versionCode = 227708, minSdk = 32),
         ),
     )
 


### PR DESCRIPTION
Applies and loads clean on Symfonium 14.0.0 TV (227708). Premium unlock not confirmed on device yet.